### PR TITLE
Delay popup of guide buffer

### DIFF
--- a/README.org
+++ b/README.org
@@ -30,8 +30,9 @@ below.
 (setq guide-key/guide-key-sequence '("C-x r" "C-x 4"))
 (guide-key-mode 1)  ; Enable guide-key-mode
 #+END_SRC
-When you press these prefix keys, key bindings are automatically popped up.
-This is a screenshot when you press "C-x r".
+When you press these prefix keys, key bindings are automatically
+popped up after a short delay (1 second by default).  This is a
+screenshot when you press "C-x r".
 
 [[http://www.kaichan.mydns.jp/~kai/wordpress/wp-content/uploads/2012/12/wpid-guide-key-example.png]]
 
@@ -53,10 +54,21 @@ adequate regular expression like this.
 #+END_SRC
 Moreover, prefix commands are automatically highlighted.
 
+Depending on your level of emacs experience, you may want a shorter or
+longer delay between pressing a key and the appearance of the guide
+buffer.  This can be controlled by setting =guide-key/idle-delay=:
+#+BEGIN_SRC emacs-lisp
+(setq guide-key/idle-delay 0.1)
+#+END_SRC
+The guide buffer is displayed only when you pause between keystrokes
+for longer than this delay, so it will keep out of your way when you
+are typing key sequences that you already know well.
+
 I've confirmed that guide-key works well in these environments.
 - Emacs 24.2, Ubuntu 12.04 or Windows 7 64bit
 - Emacs 23.3, Ubuntu 12.04 or Windows 7 64bit
 - Emacs 22.3, Windows 7 64bit
+- Emacs 24.3.1, OS X 10.9
 If popwin works good, I think guide-key also works good. You can use
 guide-key with Emacs working in terminal.
 ** Advanced Usage
@@ -104,6 +116,11 @@ Here are some functions and variables which control guide-key.
      ~left~, ~top~. The default value is ~right~.
 - *guide-key/polling-time*: This variable controls a polling time. The
      default value is 0.1 (in seconds).
+- *guide-key/idle-delay*: This variable controls the delay between
+  starting a key sequence and popping up the guide buffer. The default
+  value is 1.0 (in seconds), which means that guide-key will keep out
+  of your way unless you hesitate in the middle of a key sequence .
+  Set this to 0.0 to revert to the old default behavior.
 ** Known issues
 Here are some issues and drawbacks.
 - Because guide-key tries to pop up all key bindings, a size of popup window

--- a/guide-key.el
+++ b/guide-key.el
@@ -160,7 +160,7 @@ are allowed."
   :type 'float
   :group 'guide-key)
 
-(defcustom guide-key/idle-delay 0.5
+(defcustom guide-key/idle-delay 1.0
   "*Delay in seconds before guide buffer is displayed."
   :type 'float
   :group 'guide-key)


### PR DESCRIPTION
I prefer for the guide buffer to show only when I hesitate after pressing a key.  So I implemented this using an idle timer, configured via `guide-key/idle-delay`

Note that it isn't enough to simply increase `guide-key/polling-time`, since that does not give a constant predictable delay. 
