### PR TITLE
Add support for major-mode specific prefixes

### DIFF
--- a/guide-key.el
+++ b/guide-key.el
@@ -171,8 +171,15 @@
   "*Key sequences to guide in `guide-key-mode'.
 This variable is a list of string representation.
 Both representations, like \"C-x r\" and \"\\C-xr\",
-are allowed."
-  :type '(repeat string)
+are allowed.
+
+In addition, an element of this list can be a list with car a
+symbol representing major mode, and cdr a list of key sequences
+to consider only if this major mode is active."
+  :type '(repeat (choice (string :tag "Prefix key sequence")
+                         (cons :tag "Major-mode specific sequence"
+                               (symbol :tag "Major mode")
+                               (repeat (string :tag "Prefix key sequence")))))
   :group 'guide-key)
 
 (defcustom guide-key/polling-time 0.1
@@ -353,7 +360,8 @@ window.  Otherwise, return the width of popup window"
   "Return t if guide buffer should be popped up."
   (and (> (length key-seq) 0)
        (or (member key-seq (mapcar 'guide-key/convert-key-sequence-to-vector
-                                   guide-key/guide-key-sequence))
+                                   (append (cl-remove-if 'listp guide-key/guide-key-sequence)
+                                           (cdr (assoc major-mode guide-key/guide-key-sequence)))))
            (and guide-key/recursive-key-sequence-flag
                 (guide-key/popup-guide-buffer-p (guide-key/vbutlast key-seq))))))
 


### PR DESCRIPTION
Often I only want to show popup in a specific major mode. For example, in calc-mode, there's a prefix `V` for vector operations, or `Z` for kbd related functions. In any other mode (especially modes when user inserts text), poping a help window on `V` would be quite silly. This is similarly useful in dired, ibuffer etc.

To use this one can simply add a list like `(calc-mode "V" "Z" ...)` into the `guide-key/guide-key-sequence`. So it can look something like (for example)

```
("C-x r" "C-x 4" (calc-mode "V" "Z) (dired-mode "*"))
```

This change is compatible with the old data format, so nobody will even notice something has changed (that is, the bindings that aren't in any list are "global").
