### PR TITLE
Add the helper commands for setup major-mode

### DIFF
--- a/guide-key.el
+++ b/guide-key.el
@@ -552,6 +552,12 @@ appropriate face is not found."
          (add-to-list 'guide-key/highlight-command-regexp regexp))))
 
 (defmacro* guide-key/setup-local-keystroke (mode &key kbd not-highlight)
+  "Setup hook for MODE about the keystroke for popup guide on MODE.
+
+MODE is a symbol like 'org-mode.
+KBD is a string or list of string as keystroke.
+If NOT-HIGHLIGHT is non-nil, the MODE commands is not highlighted.
+In default, highlight the commands that matches the beginning of the name is MODE."
   (let ((forms (loop for keystroke in (if (stringp (eval kbd))
                                           (list (eval kbd))
                                         (eval kbd))
@@ -571,6 +577,10 @@ appropriate face is not found."
           (add-hook ',hook ',func t)))))
 
 (defmacro guide-key/setup-local-highlight (mode &rest regexp-list)
+  "Setup hook for MODE about the highlight of guide on MODE.
+
+MODE is a symbol like 'org-mode.
+REGEXP-LIST is argument for `guide-key/add-local-highlight-command-regexp'."
   (let ((forms (loop for re in regexp-list
                      collect `(guide-key/add-local-highlight-command-regexp ,re)))
         (hook (intern-soft (concat (symbol-name (eval mode)) "-hook")))


### PR DESCRIPTION
The following config is a bother for me.

``` lisp
(defun guide-key/my-hook-function-for-org-mode ()
  (guide-key/add-local-guide-key-sequence "C-c")
  (guide-key/add-local-guide-key-sequence "C-c C-x")
  (guide-key/add-local-highlight-command-regexp "org-"))
(add-hook 'org-mode-hook 'guide-key/my-hook-function-for-org-mode)
```

So, I've added the helper for the user like me.
The usage is the following.

``` lisp
;; Basic
(guide-key/setup-local-keystroke 'org-mode :kbd "C-c C-x")
;; If keystroke is multiple
;; (guide-key/setup-local-keystroke 'org-mode :kbd '("C-c" "C-c C-x"))
;; If org-... is not highlighted
;; (guide-key/setup-local-keystroke 'org-mode :kbd "C-c C-x" :not-highlight t)

;; If add the highlight rule
(guide-key/setup-local-highlight 'org-mode "\\`outline-")
```

Best regards.
