### PR TITLE
add customize variable guide-key-mode-lighter

### DIFF
--- a/guide-key.el
+++ b/guide-key.el
@@ -216,6 +216,11 @@
   :group 'help
   :prefix "guide-key/")
 
+(defcustom guide-key-mode-lighter " Guide"
+  "Lighter of guide-key-mode"
+  :type 'string
+  :group 'guide-key)
+
 (defcustom guide-key/guide-key-sequence nil
   "*Key sequences to guide in `guide-key-mode'.
 This variable is a list of string representation.
@@ -347,7 +352,7 @@ automatically and dynamically.
 With a prefix argument ARG, enable guide key mode if ARG is
 positive, otherwise disable."
   :global t
-  :lighter " Guide"
+  :lighter guide-key-mode-lighter
   (funcall (if guide-key-mode
                'guide-key/turn-on-timer
              'guide-key/turn-off-timer)))


### PR DESCRIPTION
The lighter of this mode is fixed as " Guide", and unable to change.
I added the new custimeze variable `guide-key-mode-lighter' and set this variable as the lighter of this mode. I think this is a usual way of the minor mode of Emacs.
